### PR TITLE
Check for same closing tag

### DIFF
--- a/mlx/parser.mly
+++ b/mlx/parser.mly
@@ -2509,7 +2509,7 @@ simple_expr:
       props=llist(jsx_attr)
     GREATER 
       children=llist(jsx_children)
-    LESSSLASH mkrhs(val_longident) GREATER {
+    LESSSLASH tag_close=mkrhs(val_longident) GREATER {
     let loc = $loc(tag_open) in
     let tag = mkexp ~loc (Pexp_ident tag_open) in
 
@@ -2522,7 +2522,18 @@ simple_expr:
       Nolabel, mkunit ~loc
     ] in
 
-    Pexp_apply (tag, props @ default_args )
+    if tag_open.txt <> tag_close.txt then
+      let tag_to_str t = Longident.flatten t |> String.concat "." in
+      let position_pair_to_string (start_pos, end_pos) =
+        Printf.sprintf "line %d-%d, characters %d-%d"
+          start_pos.Lexing.pos_lnum
+          end_pos.Lexing.pos_lnum
+          (start_pos.Lexing.pos_cnum - start_pos.Lexing.pos_bol)
+          (end_pos.Lexing.pos_cnum - end_pos.Lexing.pos_bol)
+      in
+
+      failwith ("Open and close tags don't match: '" ^ tag_to_str tag_open.txt ^ "' and '" ^ tag_to_str tag_close.txt ^ "'.  See " ^ position_pair_to_string loc)
+    else Pexp_apply (tag, props @ default_args )
   }
 
 /* handle the cases with no children and a self-closing tag */

--- a/mlx_test/run.t
+++ b/mlx_test/run.t
@@ -2,3 +2,9 @@ Test the (dialect ...) stanza inside the dune-project file.
 
   $ cat self_closing.mlx | mlx
   $ cat open_and_close.mlx | mlx
+
+Tag must be closed by same tag
+  $ cat wrong_closing_tag.mlx | mlx
+  Found an error in line:
+  let _ = <spoon></span>
+                        ^ Failure("Open and close tags don't match: 'spoon' and 'span'.  See line 1-1, characters 9-14")

--- a/mlx_test/wrong_closing_tag.mlx
+++ b/mlx_test/wrong_closing_tag.mlx
@@ -1,0 +1,1 @@
+let _ = <spoon></span>


### PR DESCRIPTION
Patch checks that a tag is always closed with the same tag.

If the closing tag is different from the opening tag, an error is reported.

There's a test case, but the test needs to be still promoted - for some reason I'm just fumbling around failing to run the tests.