### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 _build
+# nix ignores
+.direnv
+result
+.envrc

--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,7 @@
   (ocaml (>= "5.0.0"))
   (dune (>= "3.10.0"))
   (mlx :version)
+  tyxml
  ))
 
 (package

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Simple JSX support for OCaml";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }:
+        let
+          inherit (pkgs) ocamlPackages mkShell;
+          inherit (ocamlPackages) buildDunePackage;
+          version = "0.0.1";
+        in
+          {
+            devShells = {
+              default = mkShell {
+                buildInputs = [ ocamlPackages.utop ];
+                inputsFrom = [ self'.packages.default ];
+              };
+            };
+
+            packages = {
+              default = buildDunePackage {
+                inherit version;
+                pname = "mlx";
+                nativeBuildInputs = with ocamlPackages; [ menhir ];
+                propagatedBuildInputs = with ocamlPackages; [ ppxlib ];
+                src = ./.;
+              };
+              mlx_htmx = buildDunePackage {
+                inherit version;
+                pname = "mlx_htmx";
+                propagatedBuildInputs = with ocamlPackages; [
+                  self'.packages.default
+                  tyxml
+                ];
+                src = ./.;
+              };
+              mlx_test = buildDunePackage {
+                inherit version;
+                pname = "mlx_test";
+                propagatedBuildInputs = [
+                  self'.packages.default
+                  self'.packages.mlx_htmx
+                ];
+                src = ./.;
+              };
+            };
+          };
+    };
+}


### PR DESCRIPTION
Adds a nix flake for mlx, mlx_htmx, mlx_test. Also adds a dependency not specified in the dune_project for mlx_htmx.